### PR TITLE
MCP actions server for client side MCP tools

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,14 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Debug Actions Server",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "pnpm test",
+      "cwd": "${workspaceFolder}/packages/actions-server",
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
       "type": "chrome",
       "request": "launch",
       "name": "Workbench",

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ For a detailed architectural overview, please refer to our [arc42 Architecture D
 
 #### [Files Management Package](/packages/files-management/README.md)
 
-
 Implements file system operations and synchronization between browser and local environments.
 Provides a mechanism for typical version control (commits, branches, ...).
 

--- a/packages/actions-server/README.md
+++ b/packages/actions-server/README.md
@@ -254,27 +254,3 @@ class ErrorHandler {
   static handleProtocolError(error: Error): void;
 }
 ```
-
-## Testing
-
-### Unit Tests
-```typescript
-describe('ActionsServer', () => {
-  it('should register client tools', async () => {
-    // Test implementation
-  });
-  
-  it('should proxy tool execution', async () => {
-    // Test implementation
-  });
-});
-```
-
-### Integration Tests
-```typescript
-describe('ActionsServer Integration', () => {
-  it('should handle full tool lifecycle', async () => {
-    // Test implementation
-  });
-});
-```

--- a/packages/actions-server/README.md
+++ b/packages/actions-server/README.md
@@ -1,0 +1,280 @@
+# Actions Server
+
+## Purpose
+
+The Actions Server enables server-side LLM agents to safely interact with client-side tools running in browser sandboxes. It:
+- Provides a WebSocket endpoint for client connections
+- Manages client-specific tool registrations
+- Exposes client tools to server-side agents
+- Proxies tool executions between agents and clients
+
+## System Flow
+
+### 1. Initial Setup & Tool Registration
+```mermaid
+sequenceDiagram
+    participant Client
+    participant ActionsServer
+    participant Agent
+
+    Note over Client: Workbench starts
+    Client->>Client: Generate clientId
+    Client->>ActionsServer: POST /register-tools
+    Note over Client: Send tool definitions
+    ActionsServer->>ActionsServer: Store tool-client mapping
+    ActionsServer->>Client: Return { clientId }
+    ActionsServer->>Agent: Expose available tools
+```
+
+### 2. Tool Execution
+```mermaid
+sequenceDiagram
+    participant LLM
+    participant Agent
+    participant ActionsServer
+    participant Client
+
+    LLM->>Agent: Use client tool
+    Note over Agent: LLM received clientId & clientSecret from client onMessage
+    Agent->>ActionsServer: Execute tool with clientId & clientSecret
+    ActionsServer->>Client: Forward via WebSocket
+    Client->>Client: Validate clientSecret
+    Client->>Client: Execute in sandbox
+    Client->>ActionsServer: Return result
+    ActionsServer->>Agent: Forward result
+    Agent->>LLM: Process result
+```
+
+## Core Components
+
+### 1. WebSocket Connection Manager
+```typescript
+interface ClientConnection {
+  clientId: string;
+  connection: WebSocket;
+  tools: Map<string, ProxiedTool>;
+  status: 'connected' | 'disconnected';
+}
+
+class WebSocketManager {
+  private connections: Map<string, ClientConnection>;
+  
+  async handleConnection(ws: WebSocket, clientId: string): Promise<void>;
+  async handleDisconnection(clientId: string): Promise<void>;
+  async sendToClient(clientId: string, message: ServerMessage): Promise<void>;
+}
+```
+
+### 2. Tool Registry
+```typescript
+interface ProxiedTool {
+  name: string;
+  description: string;
+  parameters: JSONSchema;
+  clientId: string;
+  execute: (params: unknown) => Promise<unknown>;
+}
+
+class ToolRegistry {
+  private tools: Map<string, ProxiedTool>;
+  
+  async registerTools(clientId: string, tools: Tool[]): Promise<void>;
+  async getToolsForClient(clientId: string): Promise<ProxiedTool[]>;
+  async unregisterClientTools(clientId: string): Promise<void>;
+}
+```
+
+### 3. MCP Server Integration
+```typescript
+interface McpToolDefinition {
+  name: string;
+  description: string;
+  parameters: {
+    clientId: string;
+    clientSecret: string;
+    [key: string]: unknown;
+  };
+}
+
+class McpServer {
+  private toolRegistry: ToolRegistry;
+  
+  async registerTools(tools: McpToolDefinition[]): Promise<void>;
+  async executeTool(toolName: string, params: unknown): Promise<unknown>;
+}
+```
+
+## Security Implementation
+
+### 1. Client Registration
+```typescript
+interface RegistrationResponse {
+  clientId: string;
+}
+
+class ActionsManager {
+  private clientId: string;
+  private clientSecret: string;
+
+  constructor() {
+    this.clientSecret = generateSecret(); // Generate secret locally
+  }
+
+  async registerTools(tools: McpToolDefinition[]): Promise<void> {
+    const response = await fetch('/api/register-tools', {
+      method: 'POST',
+      body: JSON.stringify(tools)
+    });
+    const { clientId } = await response.json();
+    this.clientId = clientId;
+  }
+
+  // Method to expose credentials to LLM/Agent
+  getToolCredentials(): { clientId: string; clientSecret: string } {
+    return {
+      clientId: this.clientId,
+      clientSecret: this.clientSecret
+    };
+  }
+}
+```
+
+### 2. Tool Execution Validation
+```typescript
+class ActionsManager {
+  private validateToolExecution(params: unknown): boolean {
+    const { clientId, clientSecret } = params as { clientId: string; clientSecret: string };
+    return clientId === this.clientId && clientSecret === this.clientSecret;
+  }
+
+  async handleToolExecution(params: unknown): Promise<unknown> {
+    if (!this.validateToolExecution(params)) {
+      throw new Error('Invalid client credentials');
+    }
+    // Execute tool...
+  }
+}
+```
+
+## Message Protocol
+
+### Client Messages
+```typescript
+interface ClientMessage {
+  type: 'TOOL_RESPONSE' | 'ERROR';
+  payload: {
+    clientId: string;
+    tools?: Tool[];
+    result?: unknown;
+    error?: string;
+  };
+}
+```
+
+### Server Messages
+```typescript
+interface ServerMessage {
+  type: 'TOOL_REQUEST' | 'ERROR';
+  payload: {
+    toolName: string;
+    parameters: {
+      clientId: string;
+      clientSecret: string;
+      [key: string]: unknown;
+    };
+    requestId: string;
+  };
+}
+```
+
+## Implementation Example
+
+### 1. Server Setup
+```typescript
+const server = new ActionsServer({
+  port: 3000,
+  mcpOptions: {
+    // MCP server configuration
+  }
+});
+
+await server.start();
+```
+
+### 2. Client Connection
+```typescript
+const client = new ActionsClient(ws, {
+  clientId: 'unique-client-id',
+  tools: [
+    {
+      name: 'writeFile',
+      description: 'Write to sandboxed filesystem',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string' },
+          content: { type: 'string' }
+        }
+      }
+    }
+  ]
+});
+```
+
+### 3. Agent Usage
+```typescript
+const actions = ActionsManager.getInstance();
+const result = await actions.executeToolCall('writeFile', {
+  path: '/example.txt',
+  content: 'Hello'
+});
+```
+
+## Security & Error Handling
+
+### Authentication
+```typescript
+interface AuthConfig {
+  token: string;
+  origin: string;
+  rateLimit: number;
+}
+
+class AuthManager {
+  async validateConnection(auth: AuthConfig): Promise<boolean>;
+  async validateRequest(clientId: string): Promise<boolean>;
+}
+```
+
+### Error Handling
+```typescript
+class ErrorHandler {
+  static handleConnectionError(error: Error): void;
+  static handleToolError(error: Error): void;
+  static handleProtocolError(error: Error): void;
+}
+```
+
+## Testing
+
+### Unit Tests
+```typescript
+describe('ActionsServer', () => {
+  it('should register client tools', async () => {
+    // Test implementation
+  });
+  
+  it('should proxy tool execution', async () => {
+    // Test implementation
+  });
+});
+```
+
+### Integration Tests
+```typescript
+describe('ActionsServer Integration', () => {
+  it('should handle full tool lifecycle', async () => {
+    // Test implementation
+  });
+});
+```

--- a/packages/actions-server/eslint.config.mjs
+++ b/packages/actions-server/eslint.config.mjs
@@ -1,0 +1,3 @@
+import config from "../../eslint.config.mjs";
+
+export default config;

--- a/packages/actions-server/package.json
+++ b/packages/actions-server/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "@piddie/actions-server",
+    "version": "0.1.0",
+    "type": "module",
+    "main": "dist/server.js",
+    "types": "dist/server.d.ts",
+    "scripts": {
+        "build": "tsc",
+        "start": "node dist/server.js",
+        "dev": "tsc --watch",
+        "test": "vitest run",
+        "test:watch": "vitest"
+    },
+    "dependencies": {
+        "@modelcontextprotocol/sdk": "latest",
+        "uuid": "^9.0.1",
+        "ws": "^8.16.0",
+        "zod": "^3.22.4"
+    },
+    "devDependencies": {
+        "@types/node": "^20.11.19",
+        "@types/uuid": "^9.0.8",
+        "@types/ws": "^8.5.10",
+        "typescript": "^5.3.3",
+        "vitest": "^1.3.1"
+    }
+}

--- a/packages/actions-server/src/ActionsProxy.test.ts
+++ b/packages/actions-server/src/ActionsProxy.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ActionsProxy } from "./ActionsProxy.js";
+import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { z } from "zod";
+import { WebSocket } from "ws";
+
+interface ToolResult {
+    content: Array<{
+        type: "text";
+        text: string;
+    }>;
+    _meta: Record<string, unknown>;
+    isError: boolean;
+}
+
+interface ToolRequest {
+    type: 'TOOL_REQUEST';
+    payload: {
+        toolName: string;
+        parameters: Record<string, unknown>;
+        requestId: string;
+    };
+}
+
+describe("ActionsProxy", () => {
+    let server: ActionsProxy;
+    let client: McpClient;
+    let clientId: string;
+    let wsPort: number;
+
+    beforeEach(async () => {
+        // Use a random port between 30000-40000
+        wsPort = Math.floor(Math.random() * 10000) + 30000;
+        server = new ActionsProxy(wsPort);
+
+        // Register tools before connecting
+        clientId = await server.registerTools([
+            {
+                name: "testTool",
+                description: "A test tool",
+                parameters: z.object({
+                    input: z.string()
+                })
+            }
+        ]);
+
+        // Create client and connect
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        client = new McpClient({
+            name: "test-client",
+            version: "1.0.0",
+            transport: clientTransport
+        });
+
+        // Connect after registering tools
+        await Promise.all([
+            client.connect(clientTransport),
+            server.getMcpServer().server.connect(serverTransport)
+        ]);
+    });
+
+    afterEach(async () => {
+        server.close();
+    });
+
+    it("should register tools and allow MCP client to call them", async () => {
+        // Connect WebSocket with clientId
+        const ws = new WebSocket(`ws://localhost:${wsPort}?clientId=${clientId}`);
+        await new Promise<void>((resolve) => ws.on("open", resolve));
+
+        // Set up message listener for TOOL_REQUEST
+        const requestPromise = new Promise<ToolRequest>((resolve) => {
+            ws.on('message', (data: Buffer) => {
+                const message = JSON.parse(data.toString());
+                if (message.type === 'TOOL_REQUEST') {
+                    resolve(message);
+                }
+            });
+        });
+
+        // Wait for client to be connected
+        await new Promise<void>((resolve) => {
+            const checkConnection = () => {
+                if (server.isClientConnected(clientId)) {
+                    resolve();
+                } else {
+                    setTimeout(checkConnection, 100);
+                }
+            };
+            checkConnection();
+        });
+
+        // Call the tool
+        const toolCallPromise = client.callTool({
+            name: "testTool",
+            arguments: {
+                clientId,
+                clientSecret: "test-secret",
+                input: "test input"
+            }
+        });
+
+        // Wait for TOOL_REQUEST
+        const request = await requestPromise;
+
+        // Send TOOL_RESPONSE
+        ws.send(JSON.stringify({
+            type: "TOOL_RESPONSE",
+            payload: {
+                requestId: request.payload.requestId,
+                result: { success: true, input: request.payload.parameters.input }
+            }
+        }));
+
+        // Wait for tool call result
+        const result = await toolCallPromise as ToolResult;
+
+        // Verify the response
+        expect(result.isError).toBe(false);
+        expect(result.content[0].text).toBe(JSON.stringify({ success: true, input: "test input" }));
+
+        ws.close();
+    });
+
+    it("should handle tool execution errors", async () => {
+        // Define a test tool
+        const testTool = {
+            name: "test-tool",
+            description: "A test tool",
+            parameters: z.object({
+                input: z.string()
+            })
+        };
+
+        // Register the tool
+        await server.registerTools([testTool]);
+
+        // Connect client and server using in-memory transport
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await Promise.all([
+            client.connect(clientTransport),
+            server.getMcpServer().server.connect(serverTransport)
+        ]);
+
+        // Call the tool with invalid client ID
+        const result = await client.callTool({
+            name: "test-tool",
+            arguments: {
+                clientId: "invalid-id",
+                clientSecret: "test-secret",
+                input: "test input"
+            }
+        }) as ToolResult;
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toBe("Client invalid-id not found");
+    });
+
+    it("should route messages only to the correct client", async () => {
+        // Register two different clients with different tools
+        const client1Id = await server.registerTools([
+            {
+                name: "client1Tool",
+                description: "Tool for client 1",
+                parameters: z.object({
+                    input: z.string()
+                })
+            }
+        ]);
+
+        const client2Id = await server.registerTools([
+            {
+                name: "client2Tool",
+                description: "Tool for client 2",
+                parameters: z.object({
+                    input: z.string()
+                })
+            }
+        ]);
+
+        // Create two WebSocket connections
+        const ws1 = new WebSocket(`ws://localhost:${wsPort}?clientId=${client1Id}`);
+        const ws2 = new WebSocket(`ws://localhost:${wsPort}?clientId=${client2Id}`);
+
+        // Wait for both connections to open
+        await Promise.all([
+            new Promise<void>((resolve) => ws1.on("open", resolve)),
+            new Promise<void>((resolve) => ws2.on("open", resolve))
+        ]);
+
+        // Set up message listeners for both clients
+        const client1Messages: ToolRequest[] = [];
+        const client2Messages: ToolRequest[] = [];
+
+        ws1.on('message', (data: Buffer) => {
+            const message = JSON.parse(data.toString());
+            if (message.type === 'TOOL_REQUEST') {
+                client1Messages.push(message);
+            }
+        });
+
+        ws2.on('message', (data: Buffer) => {
+            const message = JSON.parse(data.toString());
+            if (message.type === 'TOOL_REQUEST') {
+                client2Messages.push(message);
+            }
+        });
+
+        // Wait for both clients to be connected
+        await Promise.all([
+            new Promise<void>((resolve) => {
+                const checkConnection = () => {
+                    if (server.isClientConnected(client1Id)) {
+                        resolve();
+                    } else {
+                        setTimeout(checkConnection, 100);
+                    }
+                };
+                checkConnection();
+            }),
+            new Promise<void>((resolve) => {
+                const checkConnection = () => {
+                    if (server.isClientConnected(client2Id)) {
+                        resolve();
+                    } else {
+                        setTimeout(checkConnection, 100);
+                    }
+                };
+                checkConnection();
+            })
+        ]);
+
+        // Create MCP client and connect
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        const mcpClient = new McpClient({
+            name: "test-client",
+            version: "1.0.0",
+            transport: clientTransport
+        });
+
+        await Promise.all([
+            mcpClient.connect(clientTransport),
+            server.getMcpServer().server.connect(serverTransport)
+        ]);
+
+        // Call tools for both clients
+        mcpClient.callTool({
+            name: "client1Tool",
+            arguments: {
+                clientId: client1Id,
+                clientSecret: "test-secret",
+                input: "test input 1"
+            }
+        });
+
+        mcpClient.callTool({
+            name: "client2Tool",
+            arguments: {
+                clientId: client2Id,
+                clientSecret: "test-secret",
+                input: "test input 2"
+            }
+        });
+
+        // Wait for messages to be received
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        // Verify that each client only received their own messages
+        expect(client1Messages.length).toBe(1);
+        expect(client2Messages.length).toBe(1);
+        expect(client1Messages[0].payload.toolName).toBe("client1Tool");
+        expect(client2Messages[0].payload.toolName).toBe("client2Tool");
+
+        // Clean up
+        ws1.close();
+        ws2.close();
+    });
+}); 

--- a/packages/actions-server/src/ActionsProxy.ts
+++ b/packages/actions-server/src/ActionsProxy.ts
@@ -1,0 +1,209 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z, ZodObject } from "zod";
+import { v4 as uuidv4 } from "uuid";
+import { WebSocketServer, WebSocket } from "ws";
+
+interface ClientTool {
+    name: string;
+    description: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    parameters: ZodObject<any>;
+}
+
+interface ClientRegistration {
+    clientId: string;
+    tools: Map<string, ClientTool>;
+    ws?: WebSocket;
+}
+
+interface ToolRequest {
+    type: 'TOOL_REQUEST';
+    payload: {
+        toolName: string;
+        parameters: Record<string, unknown>;
+        requestId: string;
+    };
+}
+
+interface ToolResponse {
+    type: 'TOOL_RESPONSE';
+    payload: {
+        requestId: string;
+        result: unknown;
+        error?: string;
+    };
+}
+
+export class ActionsProxy {
+    private mcpServer: McpServer;
+    private clients: Map<string, ClientRegistration> = new Map();
+    private wss: WebSocketServer;
+    private pendingRequests: Map<string, (response: ToolResponse) => void> = new Map();
+    private connectedClients: Map<string, ClientRegistration> = new Map();
+
+    constructor(port: number = 9100) {
+        this.mcpServer = new McpServer({
+            name: "actions-server",
+            version: "1.0.0"
+        });
+
+        console.log('Starting WebSocket server on port:', port);
+        this.wss = new WebSocketServer({ port });
+        this.setupWebSocketServer();
+    }
+
+    private setupWebSocketServer() {
+        this.wss.on('connection', (ws: WebSocket, req) => {
+            // Extract clientId from URL query params
+            const url = new URL(req.url || '', 'ws://localhost');
+            const clientId = url.searchParams.get('clientId');
+
+            if (!clientId) {
+                ws.close(1008, 'Missing clientId parameter');
+                return;
+            }
+
+            const client = this.clients.get(clientId);
+            if (!client) {
+                ws.close(1008, 'Invalid clientId');
+                return;
+            }
+
+            // Store the WebSocket connection so that we can send requests directly to the relevant socket
+            client.ws = ws;
+            this.connectedClients.set(clientId, client);
+
+            ws.on('close', () => {
+                this.connectedClients.delete(clientId);
+            });
+
+            ws.on('message', (message: Buffer) => {
+                try {
+                    const data = JSON.parse(message.toString()) as ToolResponse;
+                    if (data.type === 'TOOL_RESPONSE') {
+                        const { requestId } = data.payload;
+                        const resolve = this.pendingRequests.get(requestId);
+                        if (resolve) {
+                            resolve(data);
+                            this.pendingRequests.delete(requestId);
+                        }
+                    }
+                } catch (error) {
+                    console.error('Error handling WebSocket message:', error);
+                }
+            });
+        });
+
+        // Log any WebSocket server errors
+        this.wss.on('error', (error) => {
+            console.error('WebSocket server error:', error);
+        });
+    }
+
+    private async sendRequest(clientId: string, request: ToolRequest): Promise<ToolResponse> {
+        const client = this.connectedClients.get(clientId);
+        if (!client || !client.ws) {
+            throw new Error(`Client ${clientId} not connected`);
+        }
+
+        return new Promise((resolve) => {
+            this.pendingRequests.set(request.payload.requestId, resolve);
+            const ws = this.connectedClients.get(clientId)?.ws;
+            if (ws && ws.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify(request));
+            }
+        });
+    }
+
+    /**
+     * Register client tools and return clientId
+     */
+    async registerTools(tools: ClientTool[]): Promise<string> {
+        const clientId = uuidv4();
+        const clientTools = new Map<string, ClientTool>();
+
+        // Register each tool with MCP server
+        for (const toolDef of tools) {
+            const extendedParams = z.object({
+                clientId: z.string(),
+                clientSecret: z.string(),
+                ...toolDef.parameters.shape
+            });
+
+            this.mcpServer.tool(
+                toolDef.name,
+                toolDef.description,
+                extendedParams.shape,
+                async (params: Record<string, unknown>) => {
+                    try {
+                        const { clientId, clientSecret, ...toolParams } = params;
+                        const client = this.clients.get(clientId as string);
+
+                        if (!client) {
+                            throw new Error(`Client ${clientId} not found`);
+                        }
+
+                        const requestId = uuidv4();
+                        const response = await this.sendRequest(clientId as string, {
+                            type: 'TOOL_REQUEST',
+                            payload: {
+                                toolName: toolDef.name,
+                                parameters: toolParams,
+                                requestId
+                            }
+                        });
+
+                        if (response.payload.error) {
+                            throw new Error(response.payload.error);
+                        }
+
+                        return {
+                            content: [{
+                                type: "text" as const,
+                                text: JSON.stringify(response.payload.result)
+                            }],
+                            _meta: {},
+                            isError: false
+                        };
+                    } catch (error) {
+                        return {
+                            content: [{
+                                type: "text" as const,
+                                text: error instanceof Error ? error.message : String(error)
+                            }],
+                            _meta: {},
+                            isError: true
+                        };
+                    }
+                }
+            );
+
+            clientTools.set(toolDef.name, toolDef);
+        }
+
+        this.clients.set(clientId, {
+            clientId,
+            tools: clientTools
+        });
+
+        return clientId;
+    }
+
+    /**
+     * Get the MCP server instance
+     */
+    getMcpServer(): McpServer {
+        return this.mcpServer;
+    }
+
+    /**
+     * Close the WebSocket server
+     */
+    close() {
+        this.wss.close();
+    }
+
+    public isClientConnected(clientId: string): boolean {
+        return this.connectedClients.has(clientId);
+    }
+} 

--- a/packages/actions-server/src/server.ts
+++ b/packages/actions-server/src/server.ts
@@ -1,0 +1,41 @@
+import { ActionsProxy } from "./ActionsProxy.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+const actionsProxy = new ActionsProxy();
+const mcpServer = actionsProxy.getMcpServer();
+
+// Connect MCP server to stdio transport
+const transport = new StdioServerTransport();
+await mcpServer.connect(transport);
+
+// Create HTTP server
+import { createServer } from "http";
+
+const server = createServer(async (req, res) => {
+    if (req.method === "POST" && req.url === "/register-tools") {
+        try {
+            const body = await new Promise<string>((resolve) => {
+                let data = "";
+                req.on("data", (chunk) => (data += chunk));
+                req.on("end", () => resolve(data));
+            });
+
+            const tools = JSON.parse(body);
+            const clientId = await actionsProxy.registerTools(tools);
+
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ clientId }));
+        } catch (error) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: String(error) }));
+        }
+    } else {
+        res.writeHead(404);
+        res.end();
+    }
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+    console.log(`Actions server running on port ${port}`);
+}); 

--- a/packages/actions-server/tsconfig.build.json
+++ b/packages/actions-server/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "noEmit": false
+  }
+}

--- a/packages/actions-server/tsconfig.json
+++ b/packages/actions-server/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/actions-server/vitest.config.ts
+++ b/packages/actions-server/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"]
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,6 +375,37 @@ importers:
         specifier: 3.1.1
         version: 3.1.1(@types/node@22.13.14)(jiti@2.4.2)(yaml@2.6.1)
 
+  packages/actions-server:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: latest
+        version: 1.10.2
+      uuid:
+        specifier: ^9.0.1
+        version: 9.0.1
+      ws:
+        specifier: ^8.16.0
+        version: 8.18.1
+      zod:
+        specifier: ^3.22.4
+        version: 3.24.2
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.19
+        version: 20.17.30
+      '@types/uuid':
+        specifier: ^9.0.8
+        version: 9.0.8
+      '@types/ws':
+        specifier: ^8.5.10
+        version: 8.18.1
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.2
+      vitest:
+        specifier: ^1.3.1
+        version: 1.6.1(@types/node@20.17.30)
+
   packages/chat-management:
     dependencies:
       dexie:
@@ -1747,6 +1778,10 @@ packages:
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
 
+  '@modelcontextprotocol/sdk@1.10.2':
+    resolution: {integrity: sha512-rb6AMp2DR4SN+kc6L1ta2NCpApyA9WYNx3CrTSZvGxq9wH71bRur+zRqPfg0vQ9mjywR7qZdX2RGHOPq3ss+tA==}
+    engines: {node: '>=18'}
+
   '@modelcontextprotocol/sdk@1.6.1':
     resolution: {integrity: sha512-oxzMzYCkZHMntzuyerehK3fV6A2Kwh5BD6CGEJSVDU2QNEhfLOptf2X7esQgaHZXHZY0oHmMsOtIDLP71UJXgA==}
     engines: {node: '>=18'}
@@ -2168,6 +2203,9 @@ packages:
   '@types/node@18.19.76':
     resolution: {integrity: sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==}
 
+  '@types/node@20.17.30':
+    resolution: {integrity: sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==}
+
   '@types/node@22.10.7':
     resolution: {integrity: sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==}
 
@@ -2186,11 +2224,17 @@ packages:
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
+  '@types/uuid@9.0.8':
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
+
   '@types/web-bluetooth@0.0.20':
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
 
   '@types/wicg-file-system-access@2023.10.5':
     resolution: {integrity: sha512-e9kZO9kCdLqT2h9Tw38oGv9UNzBBWaR1MzuAavxPcsV/7FJ3tWbU6RI3uB+yKIDPGLkGVbplS52ub0AcRLvrhA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.21.0':
     resolution: {integrity: sha512-eTH+UOR4I7WbdQnG4Z48ebIA6Bgi7WO8HvFEneeYBxG8qCOYgTOFPSg6ek9ITIDvGjDQzWHcoWHCDO2biByNzA==}
@@ -4306,6 +4350,10 @@ packages:
     resolution: {integrity: sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==}
     engines: {node: '>=16.20.0'}
 
+  pkce-challenge@5.0.0:
+    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
+    engines: {node: '>=16.20.0'}
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -4819,6 +4867,9 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
@@ -6255,6 +6306,21 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
+  '@modelcontextprotocol/sdk@1.10.2':
+    dependencies:
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.5
+      express: 5.0.1
+      express-rate-limit: 7.5.0(express@5.0.1)
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.0
+      zod: 3.24.2
+      zod-to-json-schema: 3.24.3(zod@3.24.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@modelcontextprotocol/sdk@1.6.1':
     dependencies:
       content-type: 1.0.5
@@ -6699,6 +6765,10 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@20.17.30':
+    dependencies:
+      undici-types: 6.19.8
+
   '@types/node@22.10.7':
     dependencies:
       undici-types: 6.20.0
@@ -6717,9 +6787,15 @@ snapshots:
 
   '@types/uuid@10.0.0': {}
 
+  '@types/uuid@9.0.8': {}
+
   '@types/web-bluetooth@0.0.20': {}
 
   '@types/wicg-file-system-access@2023.10.5': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.13.14
 
   '@typescript-eslint/eslint-plugin@8.21.0(@typescript-eslint/parser@8.21.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
@@ -6902,13 +6978,13 @@ snapshots:
     optionalDependencies:
       vite: 6.0.11(@types/node@22.13.14)(jiti@2.4.2)(yaml@2.6.1)
 
-  '@vitest/mocker@3.1.1(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(yaml@2.6.1))':
+  '@vitest/mocker@3.1.1(vite@6.0.11(@types/node@22.13.14)(jiti@2.4.2)(yaml@2.6.1))':
     dependencies:
       '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.0.11(@types/node@22.10.7)(jiti@2.4.2)(yaml@2.6.1)
+      vite: 6.0.11(@types/node@22.13.14)(jiti@2.4.2)(yaml@2.6.1)
 
   '@vitest/pretty-format@3.0.3':
     dependencies:
@@ -9133,6 +9209,8 @@ snapshots:
 
   pkce-challenge@4.1.0: {}
 
+  pkce-challenge@5.0.0: {}
+
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
@@ -9634,6 +9712,8 @@ snapshots:
 
   undici-types@5.26.5: {}
 
+  undici-types@6.19.8: {}
+
   undici-types@6.20.0: {}
 
   unicorn-magic@0.3.0: {}
@@ -9716,6 +9796,24 @@ snapshots:
       - less
       - lightningcss
       - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite-node@1.6.1(@types/node@20.17.30):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.14(@types/node@20.17.30)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
       - stylus
       - sugarss
       - supports-color
@@ -9988,6 +10086,15 @@ snapshots:
       '@types/node': 22.13.14
       fsevents: 2.3.3
 
+  vite@5.4.14(@types/node@20.17.30):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.1
+      rollup: 4.31.0
+    optionalDependencies:
+      '@types/node': 20.17.30
+      fsevents: 2.3.3
+
   vite@5.4.14(@types/node@22.10.7):
     dependencies:
       esbuild: 0.21.5
@@ -10119,6 +10226,40 @@ snapshots:
       - supports-color
       - terser
 
+  vitest@1.6.1(@types/node@20.17.30):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.4.0
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.8.1
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.14(@types/node@20.17.30)
+      vite-node: 1.6.1(@types/node@20.17.30)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.17.30
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vitest@1.6.1(@types/node@22.13.14):
     dependencies:
       '@vitest/expect': 1.6.1
@@ -10134,7 +10275,7 @@ snapshots:
       magic-string: 0.30.17
       pathe: 1.1.2
       picocolors: 1.1.1
-      std-env: 3.8.0
+      std-env: 3.8.1
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
@@ -10270,7 +10411,7 @@ snapshots:
   vitest@3.1.1(@types/node@22.13.14)(jiti@2.4.2)(yaml@2.6.1):
     dependencies:
       '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(yaml@2.6.1))
+      '@vitest/mocker': 3.1.1(vite@6.0.11(@types/node@22.13.14)(jiti@2.4.2)(yaml@2.6.1))
       '@vitest/pretty-format': 3.1.1
       '@vitest/runner': 3.1.1
       '@vitest/snapshot': 3.1.1
@@ -10439,8 +10580,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.1:
-    optional: true
+  ws@8.18.1: {}
 
   xml-name-validator@4.0.0: {}
 


### PR DESCRIPTION
 This adds an MCP server that allows client side MCP tools to be executed by MCP clients that operate server side 🤯
    
For our application this means that the files management and the runtime environment which live *inside the browser* can be exposed to any MCP client.

This will enable agent frameworks that understand MCP tools (like mastra.ai) to be employed as orchestrator in the next step